### PR TITLE
Add cancellable interface

### DIFF
--- a/puerh-core/src/main/java/io/github/mishkun/puerh/core/Feature.kt
+++ b/puerh-core/src/main/java/io/github/mishkun/puerh/core/Feature.kt
@@ -1,6 +1,6 @@
 package io.github.mishkun.puerh.core
 
-interface Feature<Msg : Any, Model : Any, Eff : Any> {
+interface Feature<Msg : Any, Model : Any, Eff : Any> : Cancelable {
     val currentState: Model
     fun accept(msg: Msg)
     fun listenState(listener: (model: Model) -> Unit): Cancelable

--- a/puerh-core/src/main/java/io/github/mishkun/puerh/core/SyncFeature.kt
+++ b/puerh-core/src/main/java/io/github/mishkun/puerh/core/SyncFeature.kt
@@ -9,10 +9,13 @@ class SyncFeature<Msg : Any, Model : Any, Eff : Any>(
 ) : Feature<Msg, Model, Eff> {
     override var currentState: Model = initialState
         private set
+
+    private var isCanceled = false
     private val stateListeners = mutableListOf<(state: Model) -> Unit>()
     private val effListeners = mutableListOf<(eff: Eff) -> Unit>()
 
     override fun accept(msg: Msg) {
+        if (isCanceled) return
         val (newState, commands) = reducer(msg, currentState)
         currentState = newState
         stateListeners.notifyAll(newState)
@@ -29,4 +32,8 @@ class SyncFeature<Msg : Any, Model : Any, Eff : Any>(
 
     override fun listenEffect(listener: (eff: Eff) -> Unit): Cancelable =
         effListeners.addListenerAndMakeCancelable(listener)
+
+    override fun cancel() {
+        isCanceled = true
+    }
 }

--- a/puerh-core/src/test/java/io/github/mishkun/puerh/core/SyncFeatureSpec.kt
+++ b/puerh-core/src/test/java/io/github/mishkun/puerh/core/SyncFeatureSpec.kt
@@ -71,6 +71,30 @@ class SyncFeatureSpec : FreeSpec({
             effects should beEmpty()
         }
     }
+    "describe feature disposal" - {
+        "it should not get any effects after calling cancel method" {
+            val testFeature = createTestFeature()
+            val effects = mutableListOf<SyncTestFeature.Eff>()
+            val subscriber: (SyncTestFeature.Eff) -> Unit = { effects.add(it) }
+
+            testFeature.listenEffect(subscriber)
+            testFeature.cancel()
+            testFeature.accept(SyncTestFeature.Msg)
+
+            effects should beEmpty()
+        }
+        "it should not get any new states after calling cancel method" {
+            val testFeature = createTestFeature()
+            val states = mutableListOf<SyncTestFeature.State>()
+            val subscriber: (SyncTestFeature.State) -> Unit = { states.add(it) }
+
+            testFeature.listenState(subscriber)
+            testFeature.cancel()
+            testFeature.accept(SyncTestFeature.Msg)
+
+            states should containExactly(SyncTestFeature.State(0))
+        }
+    }
 })
 
 private fun createTestFeature() = SyncFeature(SyncTestFeature.State(0), SyncTestFeature::reducer)


### PR DESCRIPTION
This PR closes #5 

Right now it is possible for feature to fall into infinite loop even after we don't need it. Add Cancellable interface implementation to prevent feature from looping